### PR TITLE
Doc: fix typo in the msk_cluster documentation: client_authenication => client_authentication

### DIFF
--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -114,7 +114,7 @@ The following arguments are supported:
 
 * `tls` - (Optional) Configuration block for specifying TLS client authentication. See below.
 
-#### client_authenication tls Argument Reference
+#### client_authentication tls Argument Reference
 
 * `certificate_authority_arns` - (Optional) List of ACM Certificate Authority Amazon Resource Names (ARNs).
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

This is just fixing a typo on the website documentation. A resource name is missing a letter at some point.
